### PR TITLE
0.8.6

### DIFF
--- a/uitk/__init__.py
+++ b/uitk/__init__.py
@@ -8,7 +8,7 @@ from uitk.switchboard import signals  # Make signals accessible at package root
 
 
 __package__ = "uitk"
-__version__ = "0.8.5"
+__version__ = "0.8.6"
 __path__ = [os.path.abspath(os.path.dirname(__file__))]
 
 


### PR DESCRIPTION
- file_manager: extend `_get_base_dir` to take paths as a string,  and objects in which to derive a path from, in addition to the calling frame given as an integer.  This makes setting a base directory much easier in a varying scenarios. For instance if the files are part of a package,  you can just import and pass that package as the base directory in order to load specific files from that package.