### PR TITLE
0.9.0

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,5 @@
 [![License: LGPL v3](https://img.shields.io/badge/License-LGPL%20v3-blue.svg)](https://www.gnu.org/licenses/lgpl-3.0.en.html)
-[![Version](https://img.shields.io/badge/Version-0.8.9-blue.svg)](https://pypi.org/project/uitk/)
+[![Version](https://img.shields.io/badge/Version-0.9.0-blue.svg)](https://pypi.org/project/uitk/)
 
 # UITK: Dynamic UI Management for Python with PySide2
 

--- a/uitk/__init__.py
+++ b/uitk/__init__.py
@@ -8,7 +8,7 @@ from uitk.switchboard import signals  # Make signals accessible at package root
 
 
 __package__ = "uitk"
-__version__ = "0.8.9"
+__version__ = "0.9.0"
 __path__ = [os.path.abspath(os.path.dirname(__file__))]
 
 

--- a/uitk/switchboard.py
+++ b/uitk/switchboard.py
@@ -879,14 +879,16 @@ class Switchboard(QUiLoader):
         ]
 
         def wrapper(*args, **kwargs):
-            # Initialize with the supplied args and kwargs already filtered
             filtered_kwargs = {k: v for k, v in kwargs.items() if k in param_names}
-
-            # Insert the widget if it's expected by the function signature
             if "widget" in param_names:
                 filtered_kwargs["widget"] = widget
 
-            return slot(*args, **filtered_kwargs)
+            result = slot(*args, **filtered_kwargs)
+
+            # Update slot history after calling the slot
+            self.slot_history(add=slot)
+
+            return result
 
         return wrapper
 


### PR DESCRIPTION
- swtichboard._create_slot_wrapper: Fix the missing slot history call that was mistakenly removed during the previous wrapper refactor.