### PR TITLE
0.9.1

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,5 @@
 [![License: LGPL v3](https://img.shields.io/badge/License-LGPL%20v3-blue.svg)](https://www.gnu.org/licenses/lgpl-3.0.en.html)
-[![Version](https://img.shields.io/badge/Version-0.9.0-blue.svg)](https://pypi.org/project/uitk/)
+[![Version](https://img.shields.io/badge/Version-0.9.1-blue.svg)](https://pypi.org/project/uitk/)
 
 # UITK: Dynamic UI Management for Python with PySide2
 

--- a/test/switchboard_test.py
+++ b/test/switchboard_test.py
@@ -1,4 +1,6 @@
 import unittest
+
+# from PySide2 import QtWidgets
 from uitk.switchboard import Switchboard
 
 
@@ -21,6 +23,53 @@ class TestSwitchboard(unittest.TestCase):
             with self.subTest(case=case):
                 result = case["widget_obj"].call_slot(*case["args"])
                 self.assertEqual(result, case["expected"])
+
+    def test_store_and_restore_widget_state(self):
+        test_cases = [
+            {
+                "widget_name": "spinbox",
+                "setter": lambda w, v: w.setValue(v),
+                "getter": lambda w: w.value(),
+                "initial_value": 5,
+                "new_value": 10,
+            },
+            {
+                "widget_name": "checkbox",
+                "setter": lambda w, v: w.setChecked(v),
+                "getter": lambda w: w.isChecked(),
+                "initial_value": True,
+                "new_value": False,
+            },
+            {
+                "widget_name": "button_a",
+                "setter": lambda w, v: w.setText(v),
+                "getter": lambda w: w.text(),
+                "initial_value": "Text A",
+                "new_value": "New Text",
+            },
+        ]
+
+        for case in test_cases:
+            with self.subTest(case=case):
+                widget_name = case["widget_name"]
+                widget = getattr(self.ui, widget_name)
+                setter = case["setter"]
+                getter = case["getter"]
+                initial_value = case["initial_value"]
+                new_value = case["new_value"]
+
+                # Set initial state, change it, and close the UI
+                setter(widget, initial_value)
+                setter(widget, new_value)
+                self.ui.close()
+
+                # Re-open the UI and verify the state is as expected
+                self.ui = self.sb.example
+                widget = getattr(self.ui, widget_name)
+                self.assertEqual(getter(widget), new_value)
+
+                # Cleanup: Close the UI to restore the original state
+                self.ui.close()
 
 
 if __name__ == "__main__":

--- a/uitk/__init__.py
+++ b/uitk/__init__.py
@@ -8,7 +8,7 @@ from uitk.switchboard import signals  # Make signals accessible at package root
 
 
 __package__ = "uitk"
-__version__ = "0.9.0"
+__version__ = "0.9.1"
 __path__ = [os.path.abspath(os.path.dirname(__file__))]
 
 

--- a/uitk/example/example.ui
+++ b/uitk/example/example.ui
@@ -93,22 +93,8 @@
          <property name="bottomMargin">
           <number>0</number>
          </property>
-         <item row="1" column="0">
-          <widget class="QCheckBox" name="checkbox">
-           <property name="text">
-            <string>CheckBox</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="1">
-          <widget class="QSpinBox" name="spinbox">
-           <property name="prefix">
-            <string>Spinbox:	</string>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="0" colspan="2">
-          <widget class="PushButton" name="button">
+         <item row="0" column="0">
+          <widget class="PushButton" name="button_a">
            <property name="minimumSize">
             <size>
              <width>0</width>
@@ -125,7 +111,7 @@
             <enum>Qt::RightToLeft</enum>
            </property>
            <property name="text">
-            <string>Button</string>
+            <string>Button A</string>
            </property>
            <property name="autoDefault">
             <bool>false</bool>
@@ -138,6 +124,54 @@
            </property>
            <property name="bnabled" stdset="0">
             <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QCheckBox" name="checkbox">
+           <property name="text">
+            <string>CheckBox</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="2">
+          <widget class="PushButton" name="button_b">
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>20</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>999</width>
+             <height>20</height>
+            </size>
+           </property>
+           <property name="layoutDirection">
+            <enum>Qt::RightToLeft</enum>
+           </property>
+           <property name="text">
+            <string>Button B</string>
+           </property>
+           <property name="autoDefault">
+            <bool>false</bool>
+           </property>
+           <property name="default">
+            <bool>false</bool>
+           </property>
+           <property name="flat">
+            <bool>false</bool>
+           </property>
+           <property name="bnabled" stdset="0">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="2">
+          <widget class="QSpinBox" name="spinbox">
+           <property name="prefix">
+            <string>Spinbox:	</string>
            </property>
           </widget>
          </item>

--- a/uitk/example/example_slots.py
+++ b/uitk/example/example_slots.py
@@ -18,9 +18,27 @@ class ExampleSlots:
         widget = self.sb.example.header.menu.label
         self.sb.message_box(f"{widget.text()}: Clicked")
 
+    def button_a(self, widget):
+        self.sb.message_box(f"{widget.text()}: Clicked")
+
+    def button_b_init(self, widget):
+        widget.menu.setTitle("OPTION MENU")
+        widget.menu.add(
+            "QRadioButton", setObjectName="radio_a", setText="Option A", setChecked=True
+        )
+        widget.menu.add("QRadioButton", setObjectName="radio_b", setText="Option B")
+        widget.menu.add("QRadioButton", setObjectName="radio_c", setText="Option C")
+
     @signals("released")
-    def button(self, widget):
-        self.sb.message_box(f"{widget.text()}: Released")
+    def button_b(self, widget):
+        option = (
+            "A"
+            if widget.menu.radio_a.isChecked()
+            else "B"
+            if widget.menu.radio_b.isChecked()
+            else "C"
+        )
+        self.sb.message_box(f"{widget.text()}: Option {option}")
 
     def checkbox(self, state):
         self.sb.message_box(
@@ -32,7 +50,9 @@ class ExampleSlots:
 
     @staticmethod
     def textedit_init(widget):
-        widget.setText("Initialized with this text.")
+        widget.setText(
+            "• Collapse this text edit by clicking on the three dots above it.\n\n• Widget states are restored the next time this UI is opened."
+        )
 
 
 # --------------------------------------------------------------------------------------------

--- a/uitk/switchboard.py
+++ b/uitk/switchboard.py
@@ -1124,8 +1124,11 @@ class Switchboard(QUiLoader):
         widget.ui.settings.setValue(f"{widget.name}/{signal_name}", value)
 
     def restore_widget_state(self, widget):
-        """Restores the state of a given widget.
-        This method uses the QSettings class to restore the state of a widget. The state is retrieved using a key that is a combination of the widget's object name and the signal name. The method then sets the widget's state based on the retrieved value.
+        """Restores the state of a given widget using QSettings.
+
+        This method uses the QSettings class to restore the state of a widget. The state is retrieved
+        using a key that combines the widget's object name and the signal name. If the value is found,
+        the widget's state is updated accordingly.
 
         Parameters:
             widget (QWidget): The widget whose state is to be restored.
@@ -1134,19 +1137,31 @@ class Switchboard(QUiLoader):
         if signal_name:
             value = widget.ui.settings.value(f"{widget.name}/{signal_name}")
             if value is not None:
-                # QSettings stores everything as strings, so some conversion might be neccesary
-                if signal_name == "textChanged":
-                    widget.setText(value)
-                elif signal_name == "valueChanged":
-                    if isinstance(value, str):
-                        value = float(value)
-                    widget.setValue(value)
-                elif signal_name == "currentIndexChanged":
-                    widget.setCurrentIndex(int(value))
-                elif signal_name in {"toggled", "stateChanged"}:
-                    if isinstance(value, str):
-                        value = bool(value.capitalize())
-                    widget.setChecked(int(value))
+                self._apply_state_to_widget(widget, signal_name, value)
+
+    def _apply_state_to_widget(self, widget, signal_name, value):
+        """Applies the stored state to a widget based on the given signal name.
+
+        This method updates the widget's state based on the passed-in signal name and value.
+        It handles various types of widgets and their corresponding signals.
+
+        Parameters:
+            widget (QWidget): The widget whose state is to be updated.
+            signal_name (str): The name of the signal that triggered the state change.
+            value (Union[str, float, int]): The value to set the widget's state to.
+        """
+        if signal_name == "textChanged":
+            widget.setText(value)
+        elif signal_name == "valueChanged":
+            if isinstance(value, str):
+                value = float(value)
+            widget.setValue(value)
+        elif signal_name == "currentIndexChanged":
+            widget.setCurrentIndex(int(value))
+        elif signal_name in {"toggled", "stateChanged"}:
+            if isinstance(value, str):
+                value = bool(value.capitalize())
+            widget.setChecked(int(value))
 
     def set_widget_attrs(self, ui, widget_names, **kwargs):
         """Set multiple properties, for multiple widgets, on multiple UI's at once.

--- a/uitk/widgets/mainWindow.py
+++ b/uitk/widgets/mainWindow.py
@@ -170,6 +170,8 @@ class MainWindow(
         self.widgets.add(widget)
 
         self.on_child_added.emit(widget)
+        # Restore the widgets previous state
+        self.sb.restore_widget_state(widget)
         # Connect the on_child_changed signal to the sync_widget_values method
         self.init_child_changed_signal(widget)
 
@@ -376,7 +378,17 @@ class MainWindow(
             slot_init(widget)
 
     def call_slot(self, widget, *args, **kwargs):
-        """ """
+        """Executes the associated slot for a given widget.
+
+        This method retrieves the slot corresponding to the widget's name and executes it,
+        passing along any additional arguments and keyword arguments. It also re-initializes the slot
+        if the widget's `refresh` attribute is set to True.
+
+        Parameters:
+            widget (QWidget): The widget whose associated slot is to be called.
+            *args: Variable-length argument list to pass to the slot.
+            **kwargs: Arbitrary keyword arguments to pass to the slot.
+        """
         if not isinstance(widget, QtWidgets.QWidget):
             self.logger.warning(
                 f"Expected a widget object, but received {type(widget)}"
@@ -410,7 +422,6 @@ class MainWindow(
                             rel_widget.init_slot()
 
                 if not widget.is_initialized:
-                    self.sb.restore_widget_state(widget)
                     widget.is_initialized = True
 
         return super().eventFilter(widget, event)


### PR DESCRIPTION
- switchboard: Add additional tests and example widgets.
- widgets.mainWindow: Move the call to restore widget states to the child init method.