### PR TITLE
0.9.4

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,5 @@
 [![License: LGPL v3](https://img.shields.io/badge/License-LGPL%20v3-blue.svg)](https://www.gnu.org/licenses/lgpl-3.0.en.html)
-[![Version](https://img.shields.io/badge/Version-0.9.3-blue.svg)](https://pypi.org/project/uitk/)
+[![Version](https://img.shields.io/badge/Version-0.9.4-blue.svg)](https://pypi.org/project/uitk/)
 
 # UITK: Dynamic UI Management for Python with PySide2
 

--- a/uitk/__init__.py
+++ b/uitk/__init__.py
@@ -8,7 +8,7 @@ from uitk.switchboard import signals  # Make signals accessible at package root
 
 
 __package__ = "uitk"
-__version__ = "0.9.3"
+__version__ = "0.9.4"
 __path__ = [os.path.abspath(os.path.dirname(__file__))]
 
 

--- a/uitk/widgets/mainWindow.py
+++ b/uitk/widgets/mainWindow.py
@@ -264,9 +264,10 @@ class MainWindow(
         if set_attr:
             if legal_name and name != legal_name:
                 if self.sb.registry.ui_registry.get(filename=legal_name):
-                    self.logger.warning(
-                        f"Legal name '{legal_name}' already exists. Attribute not set."
-                    )
+                    pass
+                    # self.logger.warning(
+                    #     f"Legal name '{legal_name}' already exists. Attribute not set."
+                    # )
                 else:
                     setattr(self.sb, legal_name, self)
         return legal_name
@@ -287,9 +288,10 @@ class MainWindow(
         if set_attr:
             if legal_name_no_tags and name != legal_name_no_tags:
                 if self.sb.registry.ui_registry.get(filename=legal_name_no_tags):
-                    self.logger.warning(
-                        f"Legal name without tags '{legal_name_no_tags}' already exists. Attribute not set."
-                    )
+                    pass
+                    # self.logger.warning(
+                    #     f"Legal name without tags '{legal_name_no_tags}' already exists. Attribute not set."
+                    # )
                 else:
                     setattr(self.sb, legal_name_no_tags, self)
         return legal_name_no_tags


### PR DESCRIPTION
- widgets.mainWindow: Commented out the warnings on legal name existence until a more robust solution is implemented.