### PR TITLE
0.9.5

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,5 @@
 [![License: LGPL v3](https://img.shields.io/badge/License-LGPL%20v3-blue.svg)](https://www.gnu.org/licenses/lgpl-3.0.en.html)
-[![Version](https://img.shields.io/badge/Version-0.9.4-blue.svg)](https://pypi.org/project/uitk/)
+[![Version](https://img.shields.io/badge/Version-0.9.5-blue.svg)](https://pypi.org/project/uitk/)
 
 # UITK: Dynamic UI Management for Python with PySide2
 

--- a/uitk/__init__.py
+++ b/uitk/__init__.py
@@ -4,11 +4,11 @@ import os
 import importlib
 import pkgutil
 import inspect
-from uitk.switchboard import signals  # Make signals accessible at package root
+from uitk.signals import Signals
 
 
 __package__ = "uitk"
-__version__ = "0.9.4"
+__version__ = "0.9.5"
 __path__ = [os.path.abspath(os.path.dirname(__file__))]
 
 

--- a/uitk/example/example.ui
+++ b/uitk/example/example.ui
@@ -10,7 +10,7 @@
     <x>0</x>
     <y>0</y>
     <width>200</width>
-    <height>277</height>
+    <height>300</height>
    </rect>
   </property>
   <property name="tabShape">
@@ -26,7 +26,7 @@
    <property name="minimumSize">
     <size>
      <width>200</width>
-     <height>0</height>
+     <height>130</height>
     </size>
    </property>
    <layout class="QVBoxLayout" name="verticalLayout">

--- a/uitk/example/example_slots.py
+++ b/uitk/example/example_slots.py
@@ -1,6 +1,6 @@
 # !/usr/bin/python
 # coding=utf-8
-from uitk import signals
+from uitk import Signals
 
 
 class ExampleSlots:
@@ -29,7 +29,7 @@ class ExampleSlots:
         widget.menu.add("QRadioButton", setObjectName="radio_b", setText="Option B")
         widget.menu.add("QRadioButton", setObjectName="radio_c", setText="Option C")
 
-    @signals("released")
+    @Signals("released")
     def button_b(self, widget):
         option = (
             "A"

--- a/uitk/file_manager.py
+++ b/uitk/file_manager.py
@@ -8,6 +8,57 @@ import pythontk as ptk
 
 
 class NamedTupleContainer:
+    """The NamedTupleContainer class is responsible for managing collections of named tuples.
+    The class provides methods to query, modify, extend, and remove elements within the container.
+    It is typically initialized and used by the FileManager class, which serves as the main container manager.
+    NamedTupleContainer allows for advanced manipulation of the named tuples, such as accessing specific fields across all tuples.
+
+    Attributes:
+        - `file_manager`: A reference to the FileManager object that owns this container.
+        - `named_tuples`: The list of named tuples stored in this container.
+        - `metadata`: A dictionary containing additional information like "fields" which are the named tuple fields, and an "allow_duplicates" flag.
+        - `fields`: List of named tuple fields derived from metadata.
+        - `_tuple_class`: The dynamically generated named tuple class based on `fields`.
+
+    Methods:
+        - `extend`: Add new named tuples to the container while handling duplicates.
+        - `get`: Query the named tuples based on certain conditions and optionally retrieve a specific field's value.
+        - `modify`: Modify a named tuple at a specific index.
+        - `remove`: Remove a named tuple at a specific index.
+
+    Examples:
+        - Create a new container with the FileManager class:
+        ```python
+        file_manager = FileManager()
+        container = file_manager.create("example_descriptor", objects, fields=["name", "age"])
+        ```
+
+        - Extend the container with new objects:
+        ```python
+        container.extend(new_objects, allow_duplicates=False)
+        ```
+
+        - Query the container:
+        ```python
+        adults = container.get(age=18)
+        ```
+
+        - Modify an item:
+        ```python
+        container.modify(0, name="NewName")
+        ```
+
+        - Remove an item:
+        ```python
+        container.remove(0)
+        ```
+
+    Notes:
+        - This class utilizes internal logging. The logging level can be set during instantiation.
+        - The class defines custom `__iter__` and `__repr__` methods to iterate over the named tuples and represent the object.
+        - Uses the `namedtuple` class from Python's standard library to dynamically create tuple classes.
+    """
+
     def __init__(
         self,
         file_manager,

--- a/uitk/signals.py
+++ b/uitk/signals.py
@@ -1,0 +1,41 @@
+# !/usr/bin/python
+# coding=utf-8
+from functools import wraps
+
+
+class Signals:
+    """Class-based decorator to annotate slot methods with the signals to which they should connect.
+
+    This class takes one or more signal names as strings during initialization and assigns them as attributes
+    to the decorated function. The signals can be later retrieved for connecting the slot method to the respective signals.
+
+    Attributes:
+        signals (tuple of str): Tuple containing one or more signal names as strings.
+
+    Raises:
+        ValueError: If no signals are provided during initialization.
+        TypeError: If any of the provided signals is not a string.
+
+    Example:
+        @Signals('clicked', 'pressed')
+        def on_button_interaction():
+            print("Button interacted")
+    """
+
+    def __init__(self, *signals):
+        if len(signals) == 0:
+            raise ValueError("At least one signal must be specified")
+
+        for signal in signals:
+            if not isinstance(signal, str):
+                raise TypeError(f"Signal must be a string, not {type(signal)}")
+
+        self.signals = signals
+
+    def __call__(self, func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            return func(*args, **kwargs)
+
+        wrapper.signals = self.signals
+        return wrapper

--- a/uitk/switchboard.py
+++ b/uitk/switchboard.py
@@ -4,7 +4,6 @@ import re
 import sys
 import logging
 import traceback
-from functools import wraps
 from typing import List, Union
 from inspect import signature, Parameter
 from xml.etree.ElementTree import ElementTree
@@ -12,39 +11,6 @@ from PySide2 import QtCore, QtGui, QtWidgets
 from PySide2.QtUiTools import QUiLoader
 import pythontk as ptk
 from uitk.file_manager import FileManager
-
-
-def signals(*signals):
-    """Decorator to specify the signals that a slot should be connected to.
-
-    Parameters:
-        *signals (str): One or more signal names as strings.
-
-    Returns:
-        decorator: A decorator that can be applied to a slot method.
-
-    Usage:
-        @signals('clicked')
-        def on_button_click():
-            print("Button clicked")
-    """
-
-    def decorator(func):
-        @wraps(func)
-        def wrapper(*args, **kwargs):
-            return func(*args, **kwargs)
-
-        if len(signals) == 0:
-            raise ValueError("At least one signal must be specified")
-
-        for signal in signals:
-            if not isinstance(signal, str):
-                raise TypeError(f"Signal must be a string, not {type(signal)}")
-
-        wrapper.signals = signals
-        return wrapper
-
-    return decorator
 
 
 class Switchboard(QUiLoader):
@@ -119,8 +85,9 @@ class Switchboard(QUiLoader):
             ui.show(pos="screen", app_exec=True)
     """
 
-    # return the existing QApplication object, or create a new one if none exists.
+    # Use the existing QApplication object, or create a new one if none exists.
     app = QtWidgets.QApplication.instance() or QtWidgets.QApplication(sys.argv)
+    QtCore, QtGui, QtWidgets = QtCore, QtGui, QtWidgets
 
     default_signals = {  # the signals to be connected per widget type should no signals be specified using the slot decorator.
         QtWidgets.QAction: "triggered",
@@ -1735,6 +1702,7 @@ if __name__ == "__main__":
     ui.set_style(theme="dark", style_class="translucentBgWithBorder")
 
     print(repr(ui))
+    print(sb.QtGui)
     ui.show(pos="screen", app_exec=True)
 
 logging.info(__name__)  # module name

--- a/uitk/widgets/mainWindow.py
+++ b/uitk/widgets/mainWindow.py
@@ -16,6 +16,8 @@ class MainWindow(
 ):
     on_show = QtCore.Signal()
     on_hide = QtCore.Signal()
+    on_focus_in = QtCore.Signal()
+    on_focus_out = QtCore.Signal()
     on_child_added = QtCore.Signal(object)
     on_child_changed = QtCore.Signal(object, object)
 
@@ -447,8 +449,12 @@ class MainWindow(
     def focusInEvent(self, event):
         """Override the focus event to set the current UI when this window gains focus."""
         self.sb.set_current_ui(self)
-
         super().focusInEvent(event)
+        self.on_focus_in.emit()
+
+    def focusOutEvent(self, event):
+        super().focusOutEvent(event)
+        self.on_focus_out.emit()
 
     def hideEvent(self, event):
         """Reimplement hideEvent to emit custom signal when window is hidden."""


### PR DESCRIPTION
- signals: Created a new class for the existing signals decorator that was previously located in the switchboard module. It functions in the same way, but you would now import it as:  from uitk import Signals
- file_manager: Added a better description of what the NamedTupleContainer class does and how it can be used.
- switchboard; added QtCore, QtGui, and QtWidgets as attributes to the switchboard class so that they can be accessed without having to import them in any module where you are running a switchboard instance.
- widgets.mainWindow: Added `on_focus_in` and `on_focus_out` signals to the window.