### PR TITLE
0.9.6

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,5 @@
 [![License: LGPL v3](https://img.shields.io/badge/License-LGPL%20v3-blue.svg)](https://www.gnu.org/licenses/lgpl-3.0.en.html)
-[![Version](https://img.shields.io/badge/Version-0.9.5-blue.svg)](https://pypi.org/project/uitk/)
+[![Version](https://img.shields.io/badge/Version-0.9.6-blue.svg)](https://pypi.org/project/uitk/)
 
 # UITK: Dynamic UI Management for Python with PySide2
 

--- a/uitk/__init__.py
+++ b/uitk/__init__.py
@@ -8,7 +8,7 @@ from uitk.signals import Signals
 
 
 __package__ = "uitk"
-__version__ = "0.9.5"
+__version__ = "0.9.6"
 __path__ = [os.path.abspath(os.path.dirname(__file__))]
 
 

--- a/uitk/widgets/menu.py
+++ b/uitk/widgets/menu.py
@@ -39,6 +39,7 @@ class Menu(QtWidgets.QWidget, AttributesMixin, StyleSheet):
 
         Parameters:
             parent (QtWidgets.QWidget, optional): The parent widget. Defaults to None.
+            mode (str, optional): Possible values include: 'context', 'option', and 'popup'.
             position (str, optional): The position of the menu. Can be "right", "cursorPos", a coordinate pair, or a widget.
             min_item_height (int, optional): The minimum height of items in the menu. Defaults to None.
             max_item_height (int, optional): The maximum height of items in the menu. Defaults to None.


### PR DESCRIPTION
- switchboard: Instead of exposing the PySide2 modules through the switchboard class directly,  we now lazy load any of their attributes using __getattr__.  So now a QtWidget for example can be accessed like `self.sb.QAbstractItemView` (sb being an instance of the switchboard class)