### PR TITLE
0.9.9

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,5 @@
 [![License: LGPL v3](https://img.shields.io/badge/License-LGPL%20v3-blue.svg)](https://www.gnu.org/licenses/lgpl-3.0.en.html)
-[![Version](https://img.shields.io/badge/Version-0.9.8-blue.svg)](https://pypi.org/project/uitk/)
+[![Version](https://img.shields.io/badge/Version-0.9.9-blue.svg)](https://pypi.org/project/uitk/)
 
 # UITK: Dynamic UI Management for Python with PySide2
 

--- a/uitk/__init__.py
+++ b/uitk/__init__.py
@@ -8,7 +8,7 @@ from uitk.signals import Signals
 
 
 __package__ = "uitk"
-__version__ = "0.9.8"
+__version__ = "0.9.9"
 __path__ = [os.path.abspath(os.path.dirname(__file__))]
 
 


### PR DESCRIPTION
switchboard.create_button_groups: Has two new parameters: allow_deselect (bool): Whether to allow none of the checkboxes to be selected, and:  allow_multiple (bool): Whether to allow multiple checkboxes to be selected. Giving more control over how the button group can be used.